### PR TITLE
Fix: mitigate script injection via env: indirection for inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,11 +34,14 @@ runs:
     - name: 'Check if a given path exists in the repository'
       id: check-path
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_EXIT_ON_INVALID: ${{ inputs.exit_on_invalid }}
       run: |
         # Check if a given path exists in the repository
 
         # Cannot use PATH within shell code, so remap input variable
-        CHECK_PATH="${{ inputs.path }}"
+        CHECK_PATH="$INPUT_PATH"
         if [ -z "$CHECK_PATH" ]; then
           echo "Error: path to check was NOT provided/valid ❌"
           exit 1
@@ -79,7 +82,7 @@ runs:
           echo "Path is valid ✅"
         else
           echo "Path is invalid 🚫"
-          if [ "f${{ inputs.exit_on_invalid }}" = 'ftrue' ]; then
+          if [ "f$INPUT_EXIT_ON_INVALID" = 'ftrue' ]; then
             echo "Error: path check failed ❌"
             exit 1
           fi


### PR DESCRIPTION
Security Finding: #9 (MEDIUM)

Vulnerability Details:
- Finding #9 (MEDIUM, line 41): inputs.path was template-substituted
  directly into a double-quoted bash assignment:
    CHECK_PATH="${{ inputs.path }}"
  A value containing command substitution syntax (e.g., '$(id)' or
  '"; rm -rf /workspace; "') executes at template-expansion time
  before bash parses the assignment. Double quotes in bash prevent
  word-splitting but NOT command substitution from ${{ }} expansion.

Remediation Applied:
- Both inputs (path, exit_on_invalid) now pass through the step's
  'env:' block, eliminating template-substitution injection.
- Shell code references $INPUT_PATH and $INPUT_EXIT_ON_INVALID
  instead of ${{ inputs.* }} template expressions.

Impact:
- No behavioral change for legitimate callers.
- Eliminates arbitrary code execution via crafted path values.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
